### PR TITLE
feat: Make polling interval configurable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,23 +6,17 @@ import { ChannelProvider } from './contexts/ChannelContext';
 import { ChannelFilterProvider } from './contexts/ChannelFilterContext';
 import { useTheme } from './contexts/ThemeContext';
 import { MainLayout } from './components/MainLayout';
-import { useLocalStorage } from './hooks/useLocalStorage';
-import { AppConfig } from './types/schema';
-import defaultConfig from './config/defaults.json';
 
 const App = () => {
     const { isDarkMode } = useTheme();
     const [activeTab, setActiveTab] = useState(0);
-    const [config] = useLocalStorage<AppConfig>('stream-watcher-config', defaultConfig);
 
     const theme = getAppTheme(isDarkMode);
 
     return (
         <ThemeProvider theme={theme}>
             <CssBaseline />
-            <ChannelProvider 
-                pollingIntervalSeconds={config.preferences.pollInterval}
-            >
+            <ChannelProvider>
                 <ChannelFilterProvider>
                     <MainLayout activeTab={activeTab} setActiveTab={setActiveTab} />
                 </ChannelFilterProvider>

--- a/src/components/MainLayout/components/ChannelConfiguration/ChannelConfiguration.test.tsx
+++ b/src/components/MainLayout/components/ChannelConfiguration/ChannelConfiguration.test.tsx
@@ -45,6 +45,8 @@ describe('ChannelConfiguration', () => {
             refetchChannels: vi.fn(),
             addChannel: vi.fn(),
             updateChannel: vi.fn(),
+            pollingInterval: 90,
+            setPollingInterval: vi.fn(),
         });
     });
 

--- a/src/components/MainLayout/components/ChannelConfiguration/ChannelConfiguration.tsx
+++ b/src/components/MainLayout/components/ChannelConfiguration/ChannelConfiguration.tsx
@@ -10,6 +10,7 @@ import { useChannelEdit } from '../../../../contexts/ChannelEditContext';
 import { useChannels } from '../../../../contexts/ChannelContext';
 import { useState } from 'react';
 import { ChannelConfig } from '../../../../types/schema';
+import PollingIntervalConfiguration from './components/PollingIntervalConfiguration/PollingIntervalConfiguration';
 
 export const ChannelConfiguration = () => {
     const { channels, deleteChannel, importChannels, exportChannels } = useChannels();
@@ -85,6 +86,8 @@ export const ChannelConfiguration = () => {
                     </Button>
                 </Box>
             </Box>
+
+            <PollingIntervalConfiguration />
 
             <TableContainer component={Paper}>
                 <Table>

--- a/src/components/MainLayout/components/ChannelConfiguration/components/PollingIntervalConfiguration/PollingIntervalConfiguration.tsx
+++ b/src/components/MainLayout/components/ChannelConfiguration/components/PollingIntervalConfiguration/PollingIntervalConfiguration.tsx
@@ -1,0 +1,53 @@
+import { Typography, Slider, Box } from '@mui/material';
+import { useChannels } from '../../../../../../contexts/ChannelContext';
+import { MIN_POLLING_INTERVAL, MAX_POLLING_INTERVAL } from '../../../../../../constants/config';
+
+const PollingIntervalConfiguration = () => {
+    const { pollingInterval, setPollingInterval } = useChannels();
+
+    const handleSliderChange = (_event: Event, newValue: number | number[]) => {
+        setPollingInterval(newValue as number);
+    };
+
+    const valueLabelFormat = (value: number) => {
+        if (value < 60) {
+            return `${value}s`;
+        }
+        const minutes = Math.floor(value / 60);
+        const seconds = value % 60;
+        if (seconds === 0) {
+            return `${minutes}m`;
+        }
+        return `${minutes}m ${seconds}s`;
+    };
+
+    return (
+        <Box sx={{ mt: 4 }}>
+            <Typography gutterBottom>
+                Polling Interval
+            </Typography>
+            <Typography variant="body2" color="text.secondary" gutterBottom>
+                Set how often to check for stream status updates. Shorter intervals mean quicker updates but higher resource usage.
+            </Typography>
+            <Slider
+                value={pollingInterval}
+                onChange={handleSliderChange}
+                aria-labelledby="polling-interval-slider"
+                valueLabelDisplay="auto"
+                valueLabelFormat={valueLabelFormat}
+                step={15}
+                marks={[
+                    { value: MIN_POLLING_INTERVAL, label: '30s' },
+                    { value: 90, label: '90s' },
+                    { value: 300, label: '5m' },
+                    { value: 600, label: '10m' },
+                    { value: MAX_POLLING_INTERVAL, label: '15m' },
+                ]}
+                min={MIN_POLLING_INTERVAL}
+                max={MAX_POLLING_INTERVAL}
+            />
+        </Box>
+    );
+};
+
+export default PollingIntervalConfiguration; 

--- a/src/components/MainLayout/components/ChannelConfiguration/components/PollingIntervalConfiguration/index.ts
+++ b/src/components/MainLayout/components/ChannelConfiguration/components/PollingIntervalConfiguration/index.ts
@@ -1,0 +1,1 @@
+export * from './PollingIntervalConfiguration'; 

--- a/src/components/MainLayout/components/ChannelDashboard/ChannelDashboard.test.tsx
+++ b/src/components/MainLayout/components/ChannelDashboard/ChannelDashboard.test.tsx
@@ -39,6 +39,8 @@ describe('ChannelDashboard', () => {
             importChannels: vi.fn(),
             exportChannels: vi.fn(),
             refreshChannel: vi.fn(),
+            pollingInterval: 90,
+            setPollingInterval: vi.fn(),
         });
         vi.mocked(useChannelFilter).mockReturnValue({
             globalView: 'all',

--- a/src/components/MainLayout/components/ChannelDashboard/components/ChannelGroup/ChannelGroup.test.tsx
+++ b/src/components/MainLayout/components/ChannelDashboard/components/ChannelGroup/ChannelGroup.test.tsx
@@ -36,6 +36,8 @@ const mockUseChannels = {
     importChannels: vi.fn(),
     exportChannels: vi.fn(),
     refreshChannel: vi.fn(),
+    pollingInterval: 90,
+    setPollingInterval: vi.fn(),
 };
 
 const mockUseChannelFilter: {

--- a/src/components/MainLayout/components/ChannelDashboard/components/ChannelGroup/components/ChannelCard/ChannelCard.test.tsx
+++ b/src/components/MainLayout/components/ChannelDashboard/components/ChannelGroup/components/ChannelCard/ChannelCard.test.tsx
@@ -49,6 +49,8 @@ describe('ChannelCard', () => {
             deleteChannel: vi.fn(),
             importChannels: vi.fn(),
             exportChannels: vi.fn(),
+            pollingInterval: 90,
+            setPollingInterval: vi.fn(),
         });
 
         // Mock clipboard API

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -18,4 +18,8 @@ export const CHANNEL_POLLING = {
 export const API = {
     /** Default timeout for API requests in milliseconds */
     DEFAULT_TIMEOUT_MS: 10000,
-} as const; 
+} as const;
+
+export const MIN_POLLING_INTERVAL = 30;
+export const MAX_POLLING_INTERVAL = 900;
+export const DEFAULT_POLLING_INTERVAL = 90; 

--- a/src/contexts/ChannelContext.tsx
+++ b/src/contexts/ChannelContext.tsx
@@ -52,6 +52,8 @@ interface ChannelContextType {
     deleteChannel: (channelName: string) => void;
     importChannels: (channels: ChannelConfig[]) => void;
     exportChannels: () => void;
+    pollingInterval: number;
+    setPollingInterval: (interval: number) => void;
 }
 
 const ChannelContext = createContext<ChannelContextType | null>(null);
@@ -70,15 +72,14 @@ export const useChannels = () => {
 
 interface ChannelProviderProps {
     children: React.ReactNode;
-    pollingIntervalSeconds?: number;
 }
 
 export const ChannelProvider: React.FC<ChannelProviderProps> = ({ 
-    children, 
-    pollingIntervalSeconds 
+    children
 }) => {
     const [storedChannels, setStoredChannels] = useLocalStorage<ChannelConfig[]>('channels', transformedChannels);
     const [channels, dispatch] = useReducer(channelReducer, storedChannels);
+    const [pollingInterval, setPollingInterval] = useLocalStorage('pollingInterval', 90);
 
     useEffect(() => {
         setStoredChannels(channels);
@@ -93,7 +94,7 @@ export const ChannelProvider: React.FC<ChannelProviderProps> = ({
         error, 
         refetch,
         refreshChannel,
-    } = useChannelStatus(channelNames, pollingIntervalSeconds);
+    } = useChannelStatus(channelNames, pollingInterval);
 
     const mergedChannelStates = useMemo((): ChannelState[] => {
         return channelNames.map(name => {
@@ -150,9 +151,12 @@ export const ChannelProvider: React.FC<ChannelProviderProps> = ({
         deleteChannel,
         importChannels,
         exportChannels,
+        pollingInterval,
+        setPollingInterval,
     }), [
         mergedChannelStates, isLoading, error, refetch, refreshChannel, channels, 
-        addChannel, updateChannel, deleteChannel, importChannels, exportChannels
+        addChannel, updateChannel, deleteChannel, importChannels, exportChannels,
+        pollingInterval, setPollingInterval
     ]);
 
     return (


### PR DESCRIPTION
This commit introduces a new feature allowing users to dynamically configure the stream polling interval from the channel configuration screen.

Key changes include:
- A new `PollingIntervalConfiguration` component with a slider has been added to the `ChannelConfiguration` page, enabling users to set the polling interval between 30 seconds and 15 minutes.
- The polling interval state is now managed within the `ChannelContext` and persisted to local storage, ensuring the setting is saved across sessions.
- The `ChannelProvider` has been updated to use this new context-managed state, removing the need for prop-drilling the interval.
- Unit tests have been updated to reflect the changes in the `ChannelContext`.
- Unused code related to the previous static configuration has been removed from `App.tsx`.