### PR TITLE
feat(proxy): Decouple BFF target and audience for auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,8 @@ The proxy configuration manages server behavior, authentication, and connection 
 | Variable | Local (`.env`) | Docker (`proxy.env.docker`) | Production (Cloud Run) |
 |---|---|---|---|
 | `PORT` | Optional. Defaults to `8080`. | Optional. Defaults to `8080`. | **Required.** Set by the Cloud Run environment to `8080`. |
-| `BFF_BASE_URL` | Optional. Defaults to values suitable for local development. | **Required.** Defines the URL and API key for the BFF service. | **Required.** Injected as a single `APP_CONFIG_JSON` secret from Google Secret Manager at runtime. |
+| `BFF_TARGET_URL` | Optional. The URL of the downstream BFF service. Defaults to `http://localhost:3001`. | **Required.** Defines the URL for the BFF service. | **Required.** Injected from the `cloudRunUrl` property of the `APP_CONFIG_JSON` secret. |
+| `BFF_AUDIENCE` | Optional. The audience for the ID token. Defaults to the `BFF_TARGET_URL`. | **Required.** The audience for the ID token. | **Required.** Injected from the `cloudRunUrl` property of the `APP_CONFIG_JSON` secret. |
 | `SKIP_JWT_VERIFY` | Optional. Set to `true` to disable auth checks. | Optional. Set to `true` to disable auth checks. | Not used. Defaults to `false` (verification is always enabled). |
 | `JWT_JWKS_URI` | **Required** (if JWT verification is enabled). | **Required** (if JWT verification is enabled). | **Required.** Sourced from the `cloudbuild.yaml` deployment step. |
 | `JWT_ISSUER` | **Required** (if JWT verification is enabled). | **Required** (if JWT verification is enabled). | **Required.** Sourced from the `cloudbuild.yaml` deployment step. |

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -61,6 +61,8 @@ steps:
       - '--set-env-vars'
       - >-
         FIREBASE_PROJECT_ID=$PROJECT_ID,
+        BFF_TARGET_URL=https://twitchservice-230964387213.us-central1.run.app,
+        BFF_AUDIENCE=https://twitchservice-230964387213.us-central1.run.app,
         JWT_ISSUER=https://securetoken.google.com/$PROJECT_ID,
         JWT_AUDIENCE=$PROJECT_ID,
         JWT_JWKS_URI=https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
     volumes:
       - ./packages/proxy/dev_public.pem:/secrets/jwt_pub.pem:ro
     environment:
-      NODE_ENV: production
+      NODE_ENV: development
       JWT_PUBLIC_KEY: file:///secrets/jwt_pub.pem
       JWT_JWKS_URI: ""
       DEBUG: http-proxy-middleware:*

--- a/package-lock.json
+++ b/package-lock.json
@@ -17445,6 +17445,38 @@
         "node": ">=10"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
+      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "pathe": "^2.0.1",
+        "pkg-types": "^1.3.0",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/mlly/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
     "node_modules/moo": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
@@ -22500,6 +22532,13 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
+      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -23879,6 +23918,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "firebase-admin": "^13.4.0",
+        "google-auth-library": "^10.1.0",
         "http-proxy-middleware": "^3.0.0",
         "jose": "^5.4.0",
         "morgan": "^1.10.0"
@@ -23889,6 +23929,8 @@
         "@types/morgan": "^1.9.10",
         "@types/node": "^20.12.12",
         "@types/supertest": "^6.0.3",
+        "get-func-name": "^2.0.2",
+        "local-pkg": "^0.5.1",
         "msw": "^2.10.2",
         "nodemon": "^3.1.0",
         "supertest": "^7.1.1",
@@ -24296,6 +24338,39 @@
         "undici-types": "~6.21.0"
       }
     },
+    "packages/proxy/node_modules/@vitest/browser": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-1.6.1.tgz",
+      "integrity": "sha512-9ZYW6KQ30hJ+rIfJoGH4wAub/KAb4YrFzX0kVLASvTm7nJWVC5EAv5SlzlXVl3h3DaUq5aqHlZl77nmOPnALUQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "magic-string": "^0.30.5",
+        "sirv": "^2.0.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "vitest": "1.6.1",
+        "webdriverio": "*"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": true
+        },
+        "safaridriver": {
+          "optional": true
+        },
+        "webdriverio": {
+          "optional": true
+        }
+      }
+    },
     "packages/proxy/node_modules/@vitest/expect": {
       "version": "1.6.1",
       "dev": true,
@@ -24407,6 +24482,13 @@
         "node": "*"
       }
     },
+    "packages/proxy/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/proxy/node_modules/deep-eql": {
       "version": "4.1.4",
       "dev": true,
@@ -24485,6 +24567,16 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "packages/proxy/node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "packages/proxy/node_modules/get-stream": {
       "version": "8.0.1",
       "dev": true,
@@ -24526,6 +24618,23 @@
       "version": "9.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/proxy/node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
     },
     "packages/proxy/node_modules/loupe": {
       "version": "2.3.7",
@@ -24612,6 +24721,25 @@
         "node": "*"
       }
     },
+    "packages/proxy/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "packages/proxy/node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "packages/proxy/node_modules/pretty-format": {
       "version": "29.7.0",
       "dev": true,
@@ -24629,6 +24757,23 @@
       "version": "18.3.1",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/proxy/node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "packages/proxy/node_modules/strip-final-newline": {
       "version": "3.0.0",

--- a/packages/proxy/example.env
+++ b/packages/proxy/example.env
@@ -10,11 +10,23 @@
 # The port the proxy server will listen on
 PORT=8080
 
-# The base URL of the BFF (Business For Front-End) service
-BFF_BASE_URL=http://localhost:3001
+# ----------------------------------------------------------------------------------
+# Service-to-Service Authentication
+# ----------------------------------------------------------------------------------
+# For local development, these can be the same. In more complex test scenarios,
+# you might have the proxy target a local mock server, but request a token for a
+# real staging or production audience.
+BFF_TARGET_URL=http://localhost:3001
+BFF_AUDIENCE=http://localhost:3001
 
-# --- JWT Verification (for Firebase Auth) ---
-# Set to 'true' to bypass JWT verification for local development
+# The API key for the BFF service. Not used in production where service-to-service
+# authentication is active, but useful for local development if the BFF requires it.
+BFF_API_KEY=
+# ----------------------------------------------------------------------------------
+# User (end-user) JWT Verification
+# ----------------------------------------------------------------------------------
+# Set to true to bypass JWT verification entirely.
+# WARNING: This should NEVER be true in a production environment.
 SKIP_JWT_VERIFY=true
 
 # --- The following are not used when SKIP_JWT_VERIFY is true, ---

--- a/packages/proxy/example.env.docker
+++ b/packages/proxy/example.env.docker
@@ -12,8 +12,15 @@ PORT=8080
 # When running with Docker Compose, this should be the name of the BFF service.
 BFF_BASE_URL=http://host.docker.internal:3000
 
-# When running in a container, JWT verification should be disabled.
-SKIP_JWT_VERIFY=true
+# These variables are used by the proxy when running inside Docker via `docker-compose up`.
+# The proxy will forward requests to this URL. In the default `docker-compose` setup,
+# this should point to the BFF service name and port.
+BFF_TARGET_URL=http://bff:3001
+BFF_AUDIENCE=http://bff:3001
+
+# For Docker-based development, we typically use the Firebase Auth Emulator,
+# which requires JWTs to be verified.
+SKIP_JWT_VERIFY=false
 
 # JWT verification is disabled, so the following are unused but kept for reference
 # FIREBASE_AUTH_EMULATOR_HOST=auth-emulator:9099

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -26,6 +26,8 @@
     "@types/morgan": "^1.9.10",
     "@types/node": "^20.12.12",
     "@types/supertest": "^6.0.3",
+    "get-func-name": "^2.0.2",
+    "local-pkg": "^0.5.1",
     "msw": "^2.10.2",
     "nodemon": "^3.1.0",
     "supertest": "^7.1.1",

--- a/packages/proxy/src/app.test.ts
+++ b/packages/proxy/src/app.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import { Application, Request, Response, NextFunction } from 'express';
-import { createApp } from './app.js';
 import http from 'http';
-import { AppConfig } from './config.js';
+import { GoogleAuth } from 'google-auth-library';
+import { type AppConfig } from './config.js';
+import { buildUnsignedJwt, decodeJwt } from './test-helpers/jwtHelpers.js';
 
 // Mock dotenv to prevent it from loading .env files
 vi.mock('dotenv/config', () => ({}));
@@ -16,11 +17,17 @@ vi.mock('./middleware/auth.js', () => ({
     },
 }));
 
+const fetchIdTokenMock = vi.fn(async (aud: string) => {
+    return buildUnsignedJwt({ aud });
+});
+
 describe('Express App', () => {
     let app: Application;
     let mockBffServer: http.Server;
     let mockBffUrl: string;
     let mockConfig: AppConfig;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let createApp: any;
 
     beforeAll(() => {
         return new Promise<void>((resolve) => {
@@ -46,12 +53,26 @@ describe('Express App', () => {
         });
     });
 
-    // Create a fresh app instance with a mock config for each test
-    beforeEach(() => {
+    // Isolate module imports for each test to handle module-level state in app.ts
+    beforeEach(async () => {
+        vi.resetModules();
+
+        // Spy on the prototype *before* the module is imported
+        vi.spyOn(GoogleAuth.prototype, 'getIdTokenClient').mockResolvedValue({
+            idTokenProvider: {
+                fetchIdToken: fetchIdTokenMock,
+            },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+
+        // Dynamically import the app module AFTER spying
+        const appModule = await import('./app.js');
+        createApp = appModule.createApp;
+
         mockConfig = {
             port: 8080,
-            bffBaseUrl: mockBffUrl,
-            bffApiKey: 'test-service-key',
+            bffTargetUrl: mockBffUrl,
+            bffAudience: 'https://twitchservice-230964387213.us-central1.run.app',
             jwt: {
                 jwksUri: '',
                 issuer: '',
@@ -72,6 +93,7 @@ describe('Express App', () => {
 
     afterEach(() => {
         vi.restoreAllMocks();
+        fetchIdTokenMock.mockClear();
     });
 
     it('GET /healthz should return 200 OK', async () => {
@@ -111,5 +133,32 @@ describe('Express App', () => {
         expect(response.status).toBe(200);
         expect(response.body.method).toBe('POST');
         expect(response.body.url).toBe('/api/submit');
+    });
+
+    it('should include an ID token in the Authorization header derived from google-auth-library for the BFF_BASE_URL', async () => {
+        // Force production mode so the proxy attempts to fetch an ID token
+        const originalNodeEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'production';
+
+        // Re-create the app **after** setting NODE_ENV to production to pick up the change
+        app = createApp(mockConfig);
+
+        const response = await request(app).get('/api/idtoken/test');
+
+        // The mock BFF echoes back the headers it received, so we can inspect them in the JSON body.
+        const receivedAuthHeader = response.body.headers.authorization as string | undefined;
+        expect(receivedAuthHeader).toBeDefined();
+
+        // Decode the token and check its `aud` claim
+        const [, token] = receivedAuthHeader!.split(' ');
+        const decodedToken = decodeJwt(token);
+        expect(decodedToken.aud).toBe(mockConfig.bffAudience);
+
+        // Assert our fetchIdToken was called exactly once with the expected audience
+        expect(fetchIdTokenMock).toHaveBeenCalledTimes(1);
+        expect(fetchIdTokenMock).toHaveBeenCalledWith(mockConfig.bffAudience);
+
+        // Restore NODE_ENV for subsequent tests
+        process.env.NODE_ENV = originalNodeEnv;
     });
 }); 

--- a/packages/proxy/src/config.test.ts
+++ b/packages/proxy/src/config.test.ts
@@ -1,80 +1,133 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { type AppConfig } from './config.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Prevent dotenv from loading files during tests
+// Mock the dotenv import to prevent it from loading any .env files.
+// This is crucial for creating isolated and deterministic tests.
 vi.mock('dotenv/config', () => ({}));
 
-/**
- * Utility: load the configuration fresh each time after clearing Node's module cache.
- */
-const loadConfig = async (): Promise<AppConfig> => {
-    const { default: config } = await import('./config.js');
-    return config as AppConfig;
-};
 
-/**
- * Utility: Apply a clean baseline environment and then any test-specific overrides.
- */
-const setEnv = (overrides: Record<string, string | undefined> = {}): void => {
-  Object.assign(process.env, {
-    // baseline defaults (match real-world local dev)
-    PORT: '8080',
-    // Deliberately leave BFF_BASE_URL unset so tests can check fallback logic
-    SKIP_JWT_VERIFY: 'false',
-    FIREBASE_PROJECT_ID: 'stream-watcher',
-    // allow tests to override
-    ...overrides,
-  });
-};
+describe('AppConfig', () => {
+  // Define a baseline, valid environment for most test cases.
+  // This reduces boilerplate in individual tests.
+  const defaultTestEnv = {
+    FIREBASE_PROJECT_ID: 'test-project-id',
+    JWT_ISSUER: 'https://securetoken.google.com/test-project-id',
+    JWT_AUDIENCE: 'test-project-id',
+    JWT_JWKS_URI:
+      'https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com',
+  };
 
-describe('config', () => {
-  const originalEnv = { ...process.env };
-
+  // Before each test, we ensure a clean, isolated environment.
   beforeEach(() => {
-    // Reset env *and* module cache before every test
-    process.env = { ...originalEnv };
+    // 1. Reset `process.env` to the default test environment.
+    // This provides a valid starting point for most tests.
+    process.env = { ...defaultTestEnv };
+
+    // 2. Invalidate the module cache.
+    // The `config.ts` module is evaluated once on the first `import`.
+    // To make it re-evaluate with our clean `process.env`, we must clear
+    // Vitest's cache of the module.
     vi.resetModules();
   });
 
-  afterEach(() => {
-    process.env = originalEnv; // restore
+  it('should load default configuration when no environment variables are set', async () => {
+    // For this specific test, we want a truly empty environment.
+    process.env = {};
+    // We must also skip JWT verification to avoid the projectId validation.
+    process.env.SKIP_JWT_VERIFY = 'true';
+
+    // Dynamically import the config now that the environment is set
+    const { default: config } = await import('./config.js');
+
+    expect(config.port).toBe(8080);
+    expect(config.bffTargetUrl).toBe('http://localhost:3001');
+    expect(config.bffAudience).toBe('http://localhost:3001');
+    expect(config.jwt.skipVerification).toBe(true);
+    expect(config.jwt.jwksUri).toBe(
+      'https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com'
+    );
+    expect(config.jwt.issuer).toBe('');
+    expect(config.jwt.audience).toBe('');
+    expect(config.firebase.projectId).toBe('');
   });
 
-  it('loads defaults when no env vars are provided', async () => {
-    // Provide an empty env except for required baseline
-    setEnv({ PORT: undefined, FIREBASE_PROJECT_ID: undefined, SKIP_JWT_VERIFY: 'true' });
-
-    const cfg = await loadConfig();
-    expect(cfg.port).toBe(8080);
-    expect(cfg.bffBaseUrl).toBe('http://localhost:3001');
-    expect(cfg.jwt.skipVerification).toBe(true);
-  });
-
-  it('prefers APP_CONFIG_JSON over individual env vars', async () => {
-    setEnv();
-    const secret = { cloudRunUrl: 'https://cloud.run/url' };
-    process.env.APP_CONFIG_JSON = JSON.stringify(secret);
-
-    const cfg = await loadConfig();
-    expect(cfg.bffBaseUrl).toBe(secret.cloudRunUrl);
-  });
-
-  it('falls back to BFF_BASE_URL when APP_CONFIG_JSON is absent', async () => {
-    setEnv({ BFF_BASE_URL: 'http://custom-bff:3001' });
-
-    const cfg = await loadConfig();
-    expect(cfg.bffBaseUrl).toBe('http://custom-bff:3001');
-  });
-
-  it('throws if Firebase project ID is missing and verification is enabled', async () => {
-    setEnv({
-      SKIP_JWT_VERIFY: 'false',
-      FIREBASE_PROJECT_ID: undefined,
-      VITE_FIREBASE_PROJECT_ID: undefined,
-    });
-
-    await expect(loadConfig()).rejects.toThrow(
+  it('should throw an error if JWT verification is enabled but no projectId is provided', async () => {
+    // Start with a completely empty environment for this test.
+    process.env = {};
+    // SKIP_JWT_VERIFY defaults to false, so no need to set it.
+    await expect(import('./config.js')).rejects.toThrow(
       'Missing critical configuration. Ensure FIREBASE_PROJECT_ID is set.'
     );
+  });
+
+  it('should NOT throw an error if JWT verification is skipped, even with no projectId', async () => {
+    // Start with a completely empty environment for this test.
+    process.env = {};
+    process.env.SKIP_JWT_VERIFY = 'true';
+    await expect(import('./config.js')).resolves.toBeDefined();
+  });
+
+  it('should load configuration from individual environment variables', async () => {
+    // These will overwrite the defaults set in beforeEach
+    process.env.PORT = '9999';
+    process.env.BFF_TARGET_URL = 'http://test.bff:1234';
+    process.env.BFF_AUDIENCE = 'http://test.audience';
+    process.env.SKIP_JWT_VERIFY = 'true';
+    process.env.JWT_PUBLIC_KEY = 'test-public-key';
+    process.env.JWT_JWKS_URI = 'http://test-jwks-uri';
+    process.env.JWT_ISSUER = 'test-issuer';
+    process.env.JWT_AUDIENCE = 'test-audience';
+    process.env.FIREBASE_PROJECT_ID = 'different-test-project-id';
+
+    const { default: config } = await import('./config.js');
+
+    expect(config.port).toBe(9999);
+    expect(config.bffTargetUrl).toBe('http://test.bff:1234');
+    expect(config.bffAudience).toBe('http://test.audience');
+    expect(config.jwt.skipVerification).toBe(true);
+    expect(config.jwt.publicKey).toBe('test-public-key');
+    expect(config.jwt.jwksUri).toBe('http://test-jwks-uri');
+    expect(config.jwt.issuer).toBe('test-issuer');
+    expect(config.jwt.audience).toBe('test-audience');
+    expect(config.firebase.projectId).toBe('different-test-project-id');
+  });
+
+
+  it('should use BFF_BASE_URL as a fallback for both target and audience', async () => {
+    process.env.BFF_BASE_URL = 'http://base.url';
+    process.env.BFF_AUDIENCE = '';
+
+    const { default: config } = await import('./config.js');
+
+    expect(config.bffTargetUrl).toBe('http://base.url');
+    expect(config.bffAudience).toBe('http://base.url');
+  });
+
+  it('should load BFF config from APP_CONFIG_JSON when present', async () => {
+    const secretConfig = {
+      cloudRunUrl: 'https://prod.url',
+      serviceApiKey: 'prod-api-key', // this key is ignored by the current config loader
+    };
+    process.env.APP_CONFIG_JSON = JSON.stringify(secretConfig);
+
+    const { default: config } = await import('./config.js');
+
+    // APP_CONFIG_JSON should override other env vars for bff urls
+    expect(config.bffTargetUrl).toBe('https://prod.url');
+    expect(config.bffAudience).toBe('https://prod.url');
+  });
+
+  it('should still load other env vars even when APP_CONFIG_JSON is present', async () => {
+    const secretConfig = {
+      cloudRunUrl: 'https://prod.url',
+    };
+    process.env.APP_CONFIG_JSON = JSON.stringify(secretConfig);
+    process.env.PORT = '1234';
+    process.env.FIREBASE_PROJECT_ID = 'test-project-id-from-env';
+
+    const { default: config } = await import('./config.js');
+
+    expect(config.bffAudience).toBe('https://prod.url');
+    expect(config.port).toBe(1234);
+    expect(config.firebase.projectId).toBe('test-project-id-from-env');
   });
 });

--- a/packages/proxy/src/config.ts
+++ b/packages/proxy/src/config.ts
@@ -2,7 +2,8 @@ import 'dotenv/config';
 
 export interface AppConfig {
     port: number;
-    bffBaseUrl: string;
+    bffTargetUrl: string;
+    bffAudience: string;
     jwt: {
         skipVerification?: boolean;
         publicKey?: string;
@@ -18,7 +19,8 @@ export interface AppConfig {
 // Default configuration
 const config: AppConfig = {
     port: 8080,
-    bffBaseUrl: 'http://localhost:3001',
+    bffTargetUrl: 'http://localhost:3001',
+    bffAudience: 'http://localhost:3001',
     jwt: {
         skipVerification: false,
         publicKey: '',
@@ -34,10 +36,14 @@ const config: AppConfig = {
 // Load BFF config from secrets if available
 if (process.env.APP_CONFIG_JSON) {
     const secretConfig = JSON.parse(process.env.APP_CONFIG_JSON);
-    config.bffBaseUrl = secretConfig.cloudRunUrl;
+    // In production, the target and audience are the same
+    config.bffTargetUrl = secretConfig.cloudRunUrl;
+    config.bffAudience = secretConfig.cloudRunUrl;
 } else {
     // Fallback to environment variables for local development
-    config.bffBaseUrl = process.env.BFF_BASE_URL || 'http://localhost:3001';
+    // Allows for separate target and audience, but defaults to the same URL if only BFF_BASE_URL is set
+    config.bffTargetUrl = process.env.BFF_TARGET_URL || process.env.BFF_BASE_URL || 'http://localhost:3001';
+    config.bffAudience = process.env.BFF_AUDIENCE || process.env.BFF_BASE_URL || 'http://localhost:3001';
 }
 
 // Load all other configs from environment variables.
@@ -45,7 +51,7 @@ if (process.env.APP_CONFIG_JSON) {
 config.port = Number(process.env.PORT) || 8080;
 config.jwt.skipVerification = process.env.SKIP_JWT_VERIFY === 'true';
 config.jwt.publicKey = process.env.JWT_PUBLIC_KEY || '';
-config.jwt.jwksUri = process.env.JWT_JWKS_URI || '';
+config.jwt.jwksUri = process.env.JWT_JWKS_URI || 'https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com';
 config.jwt.issuer = process.env.JWT_ISSUER || '';
 config.jwt.audience = process.env.JWT_AUDIENCE || '';
 config.firebase.projectId = process.env.FIREBASE_PROJECT_ID || process.env.VITE_FIREBASE_PROJECT_ID || '';

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -6,8 +6,8 @@ const app = createApp(config);
 const server = http.createServer(app);
 
 server.listen(config.port, () => {
-    console.log(`Proxy server listening on port ${config.port}`);
-    console.log(`Proxying API requests to ${config.bffBaseUrl}`);
+    console.log(`[server]: Proxy is running at http://localhost:${config.port}`);
+    console.log(`[server]: Proxying to ${config.bffTargetUrl}`);
 });
 
 export default app; 

--- a/packages/proxy/src/test-helpers/jwtHelpers.ts
+++ b/packages/proxy/src/test-helpers/jwtHelpers.ts
@@ -1,0 +1,23 @@
+import { JWTPayload } from 'jose';
+
+// Polyfill for Buffer for browser/edge environments if needed
+const Buffer = globalThis.Buffer || (await import('buffer')).Buffer;
+
+/** Build a minimal, unsecured JWT by hand */
+export function buildUnsignedJwt(payload: JWTPayload): string {
+  const header = { alg: 'none' };
+  const encodedHeader = Buffer.from(JSON.stringify(header)).toString('base64url');
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  // Unsecured JWTs have an empty signature part
+  return `${encodedHeader}.${encodedPayload}.`;
+}
+
+/** Quick helper to pull the payload back out by decoding it manually */
+export function decodeJwt(token: string): JWTPayload {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+        throw new Error('Invalid JWT format');
+    }
+    const payload = Buffer.from(parts[1], 'base64url').toString('utf-8');
+    return JSON.parse(payload);
+} 


### PR DESCRIPTION
This commit refactors the proxy's configuration to separate the backend service URL from the audience claim required for Google-signed ID tokens. This was necessary to enable more accurate testing of the token generation logic and to resolve 401 authentication errors in production.

Key changes:
- Replaced BFF_BASE_URL with BFF_TARGET_URL (for the proxy target) and BFF_AUDIENCE (for the token aud claim).
- Updated the production deployment in cloudbuild.yaml to provide both new environment variables to the Cloud Run service.
- Corrected the local Docker environment by setting NODE_ENV=development to prevent attempts to fetch Google credentials, resolving a startup crash.
- Refactored the proxy configuration tests to be fully isolated from the host environment by mocking dotenv and resetting process.env.
- Re-implemented the JWT test helpers to avoid reliance on the Web Crypto API (crypto.subtle), which was causing environment-specific failures.
- Updated all related documentation, including the main README.md and all example .env files.